### PR TITLE
patch-1

### DIFF
--- a/src/InlineKeyboard.php
+++ b/src/InlineKeyboard.php
@@ -47,7 +47,10 @@ class InlineKeyboard
         return $this;
     }
 
-    public function chunk(int|array $buttonsPerRow)
+    /**
+     * @param  int|array  $buttonsPerRow
+     */
+    public function chunk($buttonsPerRow)
     {
         $this->buttonsPerRow = $buttonsPerRow;
 

--- a/src/ReplyKeyboard.php
+++ b/src/ReplyKeyboard.php
@@ -41,7 +41,10 @@ class ReplyKeyboard
         return $this;
     }
 
-    public function chunk(int|array $buttonsPerRow)
+    /**
+     * @param  int|array  $buttonsPerRow
+     */
+    public function chunk($buttonsPerRow)
     {
         $this->buttonsPerRow = $buttonsPerRow;
 

--- a/src/TeleBot.php
+++ b/src/TeleBot.php
@@ -208,7 +208,10 @@ class TeleBot
             return $extension(...$params);
         }
 
-        $params = $params[0] + $this->getDefaults($name);
+        $params = isset($params[0])
+            ? $params[0] + $this->getDefaults($name)
+            : $this->getDefaults($name);
+
         $httpResponse = Http::post("https://api.telegram.org/bot{$this->token}/{$name}", $params);
 
         if (!$httpResponse->ok) {

--- a/src/TeleBot.php
+++ b/src/TeleBot.php
@@ -160,7 +160,7 @@ class TeleBot
      * @param string|string[] $method Method name, an array of method names or '*'.
      * @param array $params
      */
-    public function setDefaults(string|array $method, array $params): void
+    public function setDefaults($method, array $params): void
     {
         if (is_string($method)) {
             $this->defaultParameters[$method] = $params;


### PR DESCRIPTION
- Remove more than one type of hinting in some methods arguments, because not support more than one type of hinting on PHP 7
- Fix bug "unsupported operand types" in some cases that params are null like telegram `getMe` and `getWebhookInfo` methods.